### PR TITLE
Enable strict mode and update dashboard typings

### DIFF
--- a/src/components/ui/floating-navbar.tsx
+++ b/src/components/ui/floating-navbar.tsx
@@ -9,18 +9,20 @@ import {
 } from "framer-motion";
 import { cn } from "@/lib/utils";
 
+interface NavItem {
+  name: string;
+  link: string;
+  icon?: JSX.Element;
+  onClick?: () => void;
+}
+
 export const FloatingNav = ({
   navItems,
   className,
   rightElement,
   alwaysVisible = false,
 }: {
-  navItems: {
-    name: string;
-    link: string;
-    icon?: JSX.Element;
-    onClick?: () => void;
-  }[];
+  navItems: NavItem[];
   className?: string;
   rightElement?: React.ReactNode;
   alwaysVisible?: boolean;
@@ -65,7 +67,7 @@ export const FloatingNav = ({
           className
         )}
       >
-        {navItems.map((navItem: any, idx: number) => (
+        {navItems.map((navItem, idx) => (
           <button
             key={`link=${idx}`}
             onClick={navItem.onClick || (() => {})}

--- a/src/hooks/useFixedLinks.ts
+++ b/src/hooks/useFixedLinks.ts
@@ -8,11 +8,11 @@ export interface FixedLink {
   id: string;
   title: string;
   url: string;
-  description?: string;
-  category?: string;
-  icon?: string;
-  created_at?: string;
-  updated_at?: string;
+  description?: string | null;
+  category?: string | null;
+  icon?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
 }
 
 export const useFixedLinks = () => {

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -8,11 +8,11 @@ export interface Shortcut {
   id: string;
   title: string;
   url: string;
-  description?: string;
-  category?: string;
-  icon?: string;
-  user_id?: string;
-  created_at?: string;
+  description?: string | null;
+  category?: string | null;
+  icon?: string | null;
+  user_id?: string | null;
+  created_at?: string | null;
 }
 
 export const useShortcuts = () => {
@@ -38,7 +38,7 @@ export const useShortcuts = () => {
 
       if (error) throw error;
 
-      setShortcuts(data || []);
+      setShortcuts((data || []) as Shortcut[]);
     } catch (error: any) {
       console.error('Error fetching shortcuts:', error);
       toast({
@@ -68,7 +68,7 @@ export const useShortcuts = () => {
 
       if (error) throw error;
 
-      setShortcuts(prev => [data, ...prev]);
+      setShortcuts(prev => [data as Shortcut, ...prev]);
       
       toast({
         title: "Link criado com sucesso!",
@@ -89,19 +89,20 @@ export const useShortcuts = () => {
 
   const updateShortcut = async (id: string, updates: Partial<Shortcut>) => {
     try {
+      if (!user) throw new Error('Usuário não autenticado');
       const { data, error } = await supabase
         .from('shortcuts')
         .update(updates)
         .eq('id', id)
-        .eq('user_id', user?.id)
+        .eq('user_id', user.id)
         .select()
         .single();
 
       if (error) throw error;
 
-      setShortcuts(prev => 
-        prev.map(shortcut => 
-          shortcut.id === id ? { ...shortcut, ...data } : shortcut
+      setShortcuts(prev =>
+        prev.map(shortcut =>
+          shortcut.id === id ? { ...shortcut, ...(data as Shortcut) } : shortcut
         )
       );
 
@@ -124,11 +125,12 @@ export const useShortcuts = () => {
 
   const deleteShortcut = async (id: string) => {
     try {
+      if (!user) throw new Error('Usuário não autenticado');
       const { error } = await supabase
         .from('shortcuts')
         .delete()
         .eq('id', id)
-        .eq('user_id', user?.id);
+        .eq('user_id', user.id);
 
       if (error) throw error;
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { useAuth } from "@/hooks/useAuth";
-import { useShortcuts } from "@/hooks/useShortcuts";
+import { useShortcuts, Shortcut } from "@/hooks/useShortcuts";
 import { LinkCard } from "@/components/ui/aceternity-card";
 import { AceternityButton } from "@/components/ui/aceternity-button";
 import { ShortcutModal } from "@/components/ShortcutModal";
@@ -58,11 +58,11 @@ const FIXED_LINKS = [
 
 const Dashboard = () => {
   const [modalOpen, setModalOpen] = useState(false);
-  const [editingShortcut, setEditingShortcut] = useState(null);
+  const [editingShortcut, setEditingShortcut] = useState<Shortcut | undefined>(undefined);
   const { user, signOut } = useAuth();
   const { shortcuts, loading, deleteShortcut } = useShortcuts();
 
-  const handleEditShortcut = (shortcut: any) => {
+  const handleEditShortcut = (shortcut: Shortcut) => {
     setEditingShortcut(shortcut);
     setModalOpen(true);
   };
@@ -75,7 +75,7 @@ const Dashboard = () => {
 
   const closeModal = () => {
     setModalOpen(false);
-    setEditingShortcut(null);
+    setEditingShortcut(undefined);
   };
 
   return (
@@ -172,10 +172,10 @@ const Dashboard = () => {
               >
                 <LinkCard
                   title={link.title}
-                  description={link.description}
+                  description={link.description ?? undefined}
                   url={link.url}
                   icon={link.icon}
-                  category={link.category}
+                  category={link.category ?? undefined}
                 />
               </motion.div>
             ))}
@@ -226,7 +226,7 @@ const Dashboard = () => {
                 >
                   <LinkCard
                     title={shortcut.title}
-                    description={shortcut.description}
+                    description={shortcut.description ?? undefined}
                     url={shortcut.url}
                     icon={
                       shortcut.icon ? (
@@ -235,7 +235,7 @@ const Dashboard = () => {
                         <ExternalLink className="w-5 h-5" />
                       )
                     }
-                    category={shortcut.category}
+                    category={shortcut.category ?? undefined}
                     isPersonal={true}
                     onEdit={() => handleEditShortcut(shortcut)}
                     onDelete={() => handleDeleteShortcut(shortcut.id)}

--- a/src/pages/admin/FixedLinksAdmin.tsx
+++ b/src/pages/admin/FixedLinksAdmin.tsx
@@ -1,7 +1,7 @@
 
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { useFixedLinks } from "@/hooks/useFixedLinks";
+import { useFixedLinks, FixedLink } from "@/hooks/useFixedLinks";
 import { AdminLayout } from "@/components/admin/AdminLayout";
 import { AceternityButton } from "@/components/ui/aceternity-button";
 import { AceternityCard } from "@/components/ui/aceternity-card";
@@ -18,10 +18,10 @@ import {
 
 const FixedLinksAdmin = () => {
   const [modalOpen, setModalOpen] = useState(false);
-  const [editingLink, setEditingLink] = useState(null);
+  const [editingLink, setEditingLink] = useState<FixedLink | undefined>(undefined);
   const { fixedLinks, loading, deleteFixedLink } = useFixedLinks();
 
-  const handleEditLink = (link: any) => {
+  const handleEditLink = (link: FixedLink) => {
     setEditingLink(link);
     setModalOpen(true);
   };
@@ -34,7 +34,7 @@ const FixedLinksAdmin = () => {
 
   const closeModal = () => {
     setModalOpen(false);
-    setEditingLink(null);
+    setEditingLink(undefined);
   };
 
   const openLinkInNewTab = (url: string) => {

--- a/src/pages/user/Dashboard.tsx
+++ b/src/pages/user/Dashboard.tsx
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { useAuth } from "@/hooks/useAuth";
-import { useShortcuts } from "@/hooks/useShortcuts";
+import { useShortcuts, Shortcut } from "@/hooks/useShortcuts";
 import { useFixedLinks } from "@/hooks/useFixedLinks";
 import { LinkCard } from "@/components/ui/aceternity-card";
 import { AceternityButton } from "@/components/ui/aceternity-button";
@@ -18,12 +18,12 @@ import {
 
 const Dashboard = () => {
   const [modalOpen, setModalOpen] = useState(false);
-  const [editingShortcut, setEditingShortcut] = useState(null);
+  const [editingShortcut, setEditingShortcut] = useState<Shortcut | undefined>(undefined);
   const { user } = useAuth();
   const { shortcuts, loading: shortcutsLoading, deleteShortcut } = useShortcuts();
   const { fixedLinks, loading: fixedLinksLoading } = useFixedLinks();
 
-  const handleEditShortcut = (shortcut: any) => {
+  const handleEditShortcut = (shortcut: Shortcut) => {
     setEditingShortcut(shortcut);
     setModalOpen(true);
   };
@@ -36,7 +36,7 @@ const Dashboard = () => {
 
   const closeModal = () => {
     setModalOpen(false);
-    setEditingShortcut(null);
+    setEditingShortcut(undefined);
   };
 
   return (
@@ -121,7 +121,7 @@ const Dashboard = () => {
                 >
                   <LinkCard
                     title={link.title}
-                    description={link.description}
+                    description={link.description ?? undefined}
                     url={link.url}
                     icon={
                       link.icon ? (
@@ -130,7 +130,7 @@ const Dashboard = () => {
                         <ExternalLink className="w-5 h-5" />
                       )
                     }
-                    category={link.category}
+                    category={link.category ?? undefined}
                   />
                 </motion.div>
               ))
@@ -185,7 +185,7 @@ const Dashboard = () => {
                 >
                   <LinkCard
                     title={shortcut.title}
-                    description={shortcut.description}
+                    description={shortcut.description ?? undefined}
                     url={shortcut.url}
                     icon={
                       shortcut.icon ? (
@@ -194,7 +194,7 @@ const Dashboard = () => {
                         <ExternalLink className="w-5 h-5" />
                       )
                     }
-                    category={shortcut.category}
+                    category={shortcut.category ?? undefined}
                     isPersonal={true}
                     onEdit={() => handleEditShortcut(shortcut)}
                     onDelete={() => handleDeleteShortcut(shortcut.id)}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,7 +15,7 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
+    "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noImplicitAny": false,


### PR DESCRIPTION
## Summary
- enable TypeScript strict mode
- use proper types for floating navbar nav items
- type dashboard editing state and props
- allow `null` in shortcut and fixed link hook interfaces
- check user auth in shortcut hook

## Testing
- `npm run lint` *(fails: unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685179c6fc0c83248dc98241fdf7a2e2