### PR TITLE
Implement admin route guard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import AdminDashboard from "./pages/admin/AdminDashboard";
 import FixedLinksAdmin from "./pages/admin/FixedLinksAdmin";
+import RequireAdmin from "@/components/common/RequireAdmin";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient({
@@ -34,8 +35,22 @@ const App: React.FC = () => {
               <Routes>
                 <Route path="/" element={<Index />} />
                 <Route path="/auth" element={<Auth />} />
-                <Route path="/admin" element={<AdminDashboard />} />
-                <Route path="/admin/fixed-links" element={<FixedLinksAdmin />} />
+                <Route
+                  path="/admin"
+                  element={
+                    <RequireAdmin>
+                      <AdminDashboard />
+                    </RequireAdmin>
+                  }
+                />
+                <Route
+                  path="/admin/fixed-links"
+                  element={
+                    <RequireAdmin>
+                      <FixedLinksAdmin />
+                    </RequireAdmin>
+                  }
+                />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/components/common/RequireAdmin.tsx
+++ b/src/components/common/RequireAdmin.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
+
+interface RequireAdminProps {
+  children: JSX.Element;
+}
+
+const RequireAdmin: React.FC<RequireAdminProps> = ({ children }) => {
+  const { user, loading } = useAuth();
+
+  const isAdmin = user?.email === 'admin@linkboard.com' || user?.email?.includes('admin');
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-16 h-16 border-4 border-orange-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-muted-foreground">Carregando LinkBoard UI...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+};
+
+export default RequireAdmin;


### PR DESCRIPTION
## Summary
- add `RequireAdmin` component to protect admin pages
- secure `/admin` routes with the new guard

## Testing
- `npm run lint` *(fails: unexpected any, etc.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685179b3a1788324b8d784a65f4353bb