### PR TITLE
Fix sidebar errors and glow effect

### DIFF
--- a/src/components/sidebar-demo.tsx
+++ b/src/components/sidebar-demo.tsx
@@ -2,12 +2,12 @@
 import React, { useState } from "react";
 import { Sidebar, SidebarBody, SidebarLink } from "@/components/ui/sidebar";
 import {
-  IconArrowLeft,
-  IconBrandTabler,
-  IconSettings,
-  IconUserBolt,
-} from "@tabler/icons-react";
-import { motion } from "motion/react";
+  ArrowLeft,
+  BadgeCent,
+  Settings,
+  User2,
+} from "lucide-react";
+import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 
 export default function SidebarDemo() {
@@ -16,28 +16,28 @@ export default function SidebarDemo() {
       label: "Dashboard",
       href: "#",
       icon: (
-        <IconBrandTabler className="h-5 w-5 shrink-0 text-neutral-700 dark:text-neutral-200" />
+        <BadgeCent className="h-5 w-5 shrink-0 text-neutral-700 dark:text-neutral-200" />
       ),
     },
     {
       label: "Profile",
       href: "#",
       icon: (
-        <IconUserBolt className="h-5 w-5 shrink-0 text-neutral-700 dark:text-neutral-200" />
+        <User2 className="h-5 w-5 shrink-0 text-neutral-700 dark:text-neutral-200" />
       ),
     },
     {
       label: "Settings",
       href: "#",
       icon: (
-        <IconSettings className="h-5 w-5 shrink-0 text-neutral-700 dark:text-neutral-200" />
+        <Settings className="h-5 w-5 shrink-0 text-neutral-700 dark:text-neutral-200" />
       ),
     },
     {
       label: "Logout",
       href: "#",
       icon: (
-        <IconArrowLeft className="h-5 w-5 shrink-0 text-neutral-700 dark:text-neutral-200" />
+        <ArrowLeft className="h-5 w-5 shrink-0 text-neutral-700 dark:text-neutral-200" />
       ),
     },
   ];

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { cn } from "@/lib/utils";
 import React, { useState, createContext, useContext } from "react";
-import { AnimatePresence, motion } from "motion/react";
-import { IconMenu2, IconX } from "@tabler/icons-react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Menu, X } from "lucide-react";
 
 interface Links {
   label: string;
@@ -119,7 +119,7 @@ export const MobileSidebar = ({
         {...props}
       >
         <div className="flex justify-end z-20 w-full">
-          <IconMenu2
+          <Menu
             className="text-neutral-800 dark:text-neutral-200"
             onClick={() => setOpen(!open)}
           />
@@ -143,7 +143,7 @@ export const MobileSidebar = ({
                 className="absolute right-10 top-10 z-50 text-neutral-800 dark:text-neutral-200"
                 onClick={() => setOpen(!open)}
               >
-                <IconX />
+                <X />
               </div>
               {children}
             </motion.div>
@@ -186,3 +186,50 @@ export const SidebarLink = ({
     </a>
   );
 };
+
+export const SidebarHeader = ({ className, ...props }: React.ComponentProps<'div'>) => (
+  <div className={cn('p-4', className)} {...props} />
+);
+
+export const SidebarContent = ({ className, ...props }: React.ComponentProps<'div'>) => (
+  <div className={cn('flex-1 py-2', className)} {...props} />
+);
+
+export const SidebarFooter = ({ className, ...props }: React.ComponentProps<'div'>) => (
+  <div className={cn('p-4', className)} {...props} />
+);
+
+export const SidebarMenu = ({ className, ...props }: React.ComponentProps<'ul'>) => (
+  <ul className={cn('grid gap-1', className)} {...props} />
+);
+
+export const SidebarMenuItem = ({ className, ...props }: React.ComponentProps<'li'>) => (
+  <li className={cn(className)} {...props} />
+);
+
+export const SidebarMenuButton = ({ className, ...props }: React.ComponentProps<'button'>) => (
+  <button
+    className={cn(
+      'flex items-center gap-2 w-full rounded-md p-2 text-sm transition-colors hover:bg-muted',
+      className
+    )}
+    {...props}
+  />
+);
+
+export const SidebarTrigger = ({ className, children, ...props }: React.ComponentProps<'button'>) => {
+  const { open, setOpen } = useSidebar();
+  return (
+    <button className={cn('p-2', className)} onClick={() => setOpen(!open)} {...props}>
+      {children ?? <Menu className="w-4 h-4" />}
+    </button>
+  );
+};
+
+export const SidebarRail = ({ className, ...props }: React.ComponentProps<'div'>) => (
+  <div className={cn('hidden md:block w-0', className)} {...props} />
+);
+
+export const SidebarInset = ({ className, ...props }: React.ComponentProps<'div'>) => (
+  <div className={cn('flex-1', className)} {...props} />
+);

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -88,11 +88,11 @@ export const DesktopSidebar = ({
     <>
       <motion.div
         className={cn(
-          "h-full px-4 py-4 hidden  md:flex md:flex-col bg-neutral-100 dark:bg-neutral-800 w-[300px] shrink-0",
+          "h-full px-4 py-4 hidden md:flex md:flex-col bg-neutral-100 dark:bg-neutral-800 shrink-0",
           className
         )}
         animate={{
-          width: animate ? (open ? "300px" : "60px") : "300px",
+          width: animate ? (open ? "256px" : "64px") : "256px",
         }}
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}

--- a/src/index.css
+++ b/src/index.css
@@ -131,6 +131,11 @@
     @apply hover:before:opacity-100;
   }
 
+  /* Base styles for the GlowingEffect component */
+  .glow {
+    @apply relative;
+  }
+
   /* Floating navbar spacing */
   .floating-nav-spacing {
     @apply pt-20;


### PR DESCRIPTION
## Summary
- switch sidebar to framer-motion and lucide icons
- add basic styles for GlowingEffect
- implement missing sidebar subcomponents
- update demo icons

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68519355682c8324a00c6c25046b65e1